### PR TITLE
ci(labels): use canonical label names in labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,16 +1,15 @@
-documentation 📝:
+type:docs:
   - "docs/**/*.md"
   - "community/**/*.md"
   - "ecosystem/**/*.md"
-dependencies 📦:
+area:dependencies:
   - "package.json"
   - "pnpm-lock.yaml"
   - "yarn.lock"
-enhancement ✨:
+type:maintenance:
   - "functions/**"
   - "src/**"
   - "lib/**"
-maintenance 📈:
   - ".github/CODEOWNERS"
   - ".github/*.md"
   - ".github/*.yml"
@@ -29,10 +28,7 @@ maintenance 📈:
   - ".trunk/*.yaml"
   - ".trunk/*.json"
   - ".trunk/*rc"
-i18n 🌐:
-  - "i18n/**"
-  - "docs/i18n/**"
-annex 🌀:
+area:annex:
   - "functions/→za**"
 #package 📦:
 #  - 'ecosystem/packages/**/*.md'
@@ -40,5 +36,5 @@ annex 🌀:
 #plugin ⚙️:
 #  - 'ecosystem/plugins/**.md'
 #  - 'i18n/**/docusaurus-plugin-content-ecosystem/**/plugins/**/*.md'
-ci 🤖:
+area:ci:
   - ".github/workflows/*"


### PR DESCRIPTION
`.github/labeler.yml` named legacy labels that [#467](https://github.com/z-shell/.github/issues/467) deleted across the organization.

That is not a cosmetic mismatch. `actions/labeler` applies labels through the issues API, which **creates** a label that does not exist rather than failing. This repository runs `actions/labeler@v4` on `pull_request_target`, so every matching pull request silently recreated the deleted legacy labels and undid the org-wide cleanup, with nothing in any log explaining why they came back.

## Mapping

Each key is replaced with its `lib/labels.yml` canonical equivalent:

| Was | Now |
| --- | --- |
| `documentation 📝` | `type:docs` |
| `dependencies 📦` | `area:dependencies` |
| `enhancement ✨` | `type:maintenance` |
| `maintenance 📈` | `type:maintenance` |
| `annex 🌀` | `area:annex` |
| `ci 🤖` | `area:ci` |
| `i18n 🌐` | removed |

Two things here are more than a rename, and are worth a look rather than a skim:

- **`enhancement ✨` and `maintenance 📈` both map to `type:maintenance`**, so their glob lists merge into a single key. The practical effect is that changes under `functions/**`, `src/**`, and `lib/**` now get `type:maintenance` alongside the repository-metadata globs that already produced it.
- **`i18n 🌐` is dropped rather than translated.** It has no canonical equivalent, and this repository has never used it: the only repository in the organization that does is `z-shell/wiki`, which does not reference it from a labeler config. The key arrived here from a Docusaurus-shaped template, which is also why the config still carries `docusaurus.config.js`, `crowdin.yml`, and `i18n/**` globs for paths this repository does not have.

All 29 remaining globs are carried over unchanged. Pruning the leftover Docusaurus globs would be a real improvement but is deliberately not bundled here, so this change stays reviewable as a pure label-name correction.

## Verification

Parsed with `yaml.safe_load` and checked against `lib/labels.yml`: all five resulting keys (`type:docs`, `area:dependencies`, `type:maintenance`, `area:annex`, `area:ci`) are canonical, and the audit added in [z-shell/.github#529](https://github.com/z-shell/.github/pull/529) reports no findings for this file.

This is the pilot for the same fix in the other 16 repositories that actively run `actions/labeler`. Tracked in [z-shell/.github#527](https://github.com/z-shell/.github/issues/527).
