### PR TITLE
ci(labeler): use the default GITHUB_TOKEN instead of an unset PAT

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/labeler@v4
         with:
-          repo-token: "${{ secrets.GH_PAT }}"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
The labeler job has never applied a label in this repository. It passes `repo-token` from `secrets.GH_PAT`, which is not populated, so `actions/labeler` fails immediately:

```
##[error]Error: Parameter token or opts.auth is required
```

That is the `triage` failure seen on #5. It happens before the action reads any configuration, so it is independent of which label names the config uses.

## Why no PAT is needed

The job already declares the only permission `actions/labeler` requires for a same-repository pull request:

```yaml
permissions:
  contents: read
  pull-requests: write
```

So the default `GITHUB_TOKEN` is sufficient. This also removes a dependency on a long-lived personal access token, which is the better outcome regardless of whether `GH_PAT` is ever populated.

## Verification

This pull request triggers the workflow it changes, so the `triage` check on this PR is the test. On `main` today that check fails with the error above; here it should run to completion.

Note that `pull_request_target` runs the workflow definition from the **base** branch, so the check on this PR may still exercise the old `main` version. If it does, the real verification is the first pull request opened after this merges.

## Not included

`actions/labeler@v4` is referenced by tag rather than pinned to a commit SHA, which the organization workflow conventions ask for. Left alone to keep this change to a single line; worth a follow-up across the same set of repositories.

Part of z-shell/.github#527. This is the pilot for the same one-line fix in the other 11 repositories whose labeler workflow is active and equally unable to authenticate.
