### PR TITLE
ci(labeler): pin actions/labeler to a commit SHA

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
Organization workflow conventions require actions to be pinned to a full commit SHA. A mutable tag is unreviewed code: `v4` can be repointed by the upstream owner at any time, and this job is unusually attractive to repoint, because it runs on `pull_request_target` with `pull-requests: write`.

Pins to `ac9175f` (v4.3.0), the commit `v4` currently resolves to. No behavior change.

## This also verifies the token fix

`pull_request_target` runs the workflow definition from the **base** branch, so the `triage` check on #6 could not exercise its own fix and failed with the pre-existing `Parameter token or opts.auth is required`.

Now that #6 is merged, `main` carries `repo-token: "${{ secrets.GITHUB_TOKEN }}"`. This pull request is therefore the first one to run the labeler against the corrected workflow, and its `triage` check is the real test of whether the fix works.

Two outcomes, both useful:

- **Check succeeds:** the default token is sufficient, and the same one-line change can go out to the other 11 repositories with an active labeler workflow.
- **Check still fails:** the diagnosis was incomplete and the fan-out should not happen. Better to learn that here than in 11 more pull requests.

Part of z-shell/.github#527.
